### PR TITLE
Add dependency on pathtools

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Dropped support for Python 2 and Python 3.5
+- Added support for Python 3.8
 
 
 1.2.0 (2018-03-31)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON = python2.7
+PYTHON ?= python3.6
 
 all: ve ve/bin/zope-testrunner
 

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ setup(
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
             'pytz',
             ],
         enforce=[
-            'watchdog',
+            'watchdog>=1.0.0',
             ],
         ),
     install_requires=INSTALL_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Natural Language :: English',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/src/z3c/insist/enforce.py
+++ b/src/z3c/insist/enforce.py
@@ -13,7 +13,7 @@ import watchdog.observers
 import watchdog.utils
 import zope.component
 import zope.interface
-from pathtools.patterns import match_any_paths
+from watchdog.utils.patterns import match_any_paths
 
 from z3c.insist import interfaces, insist
 
@@ -49,7 +49,7 @@ class EnforcerEventHandler(watchdog.events.FileSystemEventHandler):
         return factory.fromRootAndFilename(self.root, path)
 
     def getStoreFromEvent(self, event):
-        path = watchdog.utils.unicode_paths.decode(event.src_path)
+        path = os.fsdecode(event.src_path)
 
         if match_any_paths([path],
                            included_patterns=self.patterns,

--- a/src/z3c/insist/tests/test_enforce.py
+++ b/src/z3c/insist/tests/test_enforce.py
@@ -152,7 +152,10 @@ class EnforcerTest(EnforcerBaseTest):
         evt = enf.dispatch_events(
             EventQueue(watchdog.events.FileModifiedEvent('./sample.ini')), 1)
         self.assertEqual(
-            "<FileModifiedEvent: src_path='./sample.ini'>\n",
+            "<FileModifiedEvent:"
+            " event_type=modified,"
+            " src_path='./sample.ini',"
+            " is_directory=False>\n",
             self.log.getvalue())
 
         # Now we are locking the directory, ...
@@ -171,7 +174,10 @@ class EnforcerTest(EnforcerBaseTest):
         enf.dispatch_events(
             EventQueue(watchdog.events.FileModifiedEvent('./sample.ini')), 1)
         self.assertEqual(
-            "<FileModifiedEvent: src_path='./sample.ini'>\n",
+            "<FileModifiedEvent:"
+            " event_type=modified,"
+            " src_path='./sample.ini',"
+            " is_directory=False>\n",
             self.log.getvalue())
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,pypy
+envlist = py35,py36,pypy
 
 [testenv]
 commands =
@@ -7,16 +7,3 @@ commands =
 deps =
     .[test,enforce]
     zope.testrunner
-
-[testenv:py27]
-# Python 2.7 is the designated coverage report run.
-basepython = python2.7
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-commands =
-    coverage erase
-    coverage run {envbindir}/zope-testrunner -vpc1 --all --test-path ./src
-    coverage xml
-    coverage report -m
-deps =
-    {[testenv]deps}
-    coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py38,pypy
+envlist = py36,py38,pypy
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,pypy
+envlist = py35,py36,py38,pypy
 
 [testenv]
 commands =


### PR DESCRIPTION
We used to get it from watchdog and since 1.0.1 watchdog switched to standard pathlib