### PR TITLE
Ignore File Opened event; update watchdog; fix some typos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 - Added support for Python 3.10 and 3.11
 
+- Ignored FileOpenedEvent in dispatch to avoid unnecessary processing of files.
+
+- Upgraded to the watchdog 3.0.0
 
 1.5.0 (2023-01-24)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
             'pytz',
             ],
         enforce=[
-            'watchdog>=2.1.7',
+            'watchdog>=3.0.0',
             ],
         ),
     install_requires=INSTALL_REQUIRES,

--- a/src/z3c/insist/enforce.py
+++ b/src/z3c/insist/enforce.py
@@ -66,7 +66,10 @@ class EnforcerEventHandler(watchdog.events.FileSystemEventHandler):
 
     def dispatch(self, event):
         if event.event_type == watchdog.events.EVENT_TYPE_OPENED:
-            # Do not update configuration for EVENT_TYPE_OPENED.
+            # Do not update configuration for EVENT_TYPE_OPENED. Doing this to avoid
+            # unnecessary processing on file open events, need this since watchdog
+            # started sending EVENT_TYPE_OPENED events. Eventually refactor dispatch
+            # and event handlers later to do work only on specific events.
             return False
         ts = time.time()
         store = self.getStoreFromEvent(event)

--- a/src/z3c/insist/enforce.py
+++ b/src/z3c/insist/enforce.py
@@ -65,6 +65,9 @@ class EnforcerEventHandler(watchdog.events.FileSystemEventHandler):
         return event.store.getSectionFromPath(event.src_path)
 
     def dispatch(self, event):
+        if event.event_type == watchdog.events.EVENT_TYPE_OPENED:
+            # Do not update configuration for EVENT_TYPE_OPENED.
+            return False
         ts = time.time()
         store = self.getStoreFromEvent(event)
         if store is None:
@@ -226,7 +229,7 @@ class Enforcer(watchdog.observers.Observer):
         event, watch = event_queue.get(block=True)
 
         with self._lock:
-            # Optimization: Ignore all dorectory modified events, since we
+            # Optimization: Ignore all directory modified events, since we
             # cannot really do anything with those. It will also avoid
             # unnecessary transactions due to lock file action.
             if event.is_directory and \
@@ -366,7 +369,7 @@ class IncludeObserver(watchdog.observers.Observer):
         super().__init__()
 
     def initialize(self) -> None:
-        logger.info(f'Initializing Include Oberver for {self.watchedDir}')
+        logger.info(f'Initializing Include Observer for {self.watchedDir}')
         for path in pathlib.Path(self.watchedDir).rglob('*.ini'):
             self.update(path)
         self.schedule(

--- a/src/z3c/insist/tests/test_enforce.py
+++ b/src/z3c/insist/tests/test_enforce.py
@@ -479,6 +479,11 @@ class FileSectionsEnforcerEventHandlerTest(EnforcerBaseTest):
         self.assertTrue(handler.dispatch(evt))
         NumbersStore.deleteItem.assert_called_with('1')
 
+        # 4. File Opened, we ignore this event and do nothing.
+        store.reset_mock()
+        evt = watchdog.events.FileOpenedEvent('./path/number:1.ini')
+        self.assertFalse(handler.dispatch(evt))
+
         # If no store is found, we simply return and do nothing:
         NumbersStore.loadFromSection.reset_mock()
         evt = watchdog.events.FileCreatedEvent('./path/int:1.ini')


### PR DESCRIPTION
Recently watchdog introduced FileOpenedEvent which is going through dispatch in the handler which caused a lot of spam in the console while IDE was opening the files. As we don't need to handle this event we can freely ignore it in the dispatch. 