### PR TITLE
chore(deps): Restrict the watchdog version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
             'pytz',
             ],
         enforce=[
-            'watchdog>=3.0.0',
+            'watchdog>=3.0.0, <4.0.0',
             ],
         ),
     install_requires=INSTALL_REQUIRES,


### PR DESCRIPTION
Hello,

The next `watchdog` release will change several things, and one is the `repr()` of events. So to prevent unexpected upgrades that will break tests, it may be interesting to restrict the major version.