### PR TITLE
Ignore FileOpenedEvent in IncludeObserver as well

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Ignored FileOpenedEvent in dispatch to avoid unnecessary processing of files in IncludingFilesHandler.
 
 
 1.5.1 (2023-03-23)

--- a/src/z3c/insist/enforce.py
+++ b/src/z3c/insist/enforce.py
@@ -69,7 +69,7 @@ class EnforcerEventHandler(watchdog.events.FileSystemEventHandler):
             # Do not update configuration for EVENT_TYPE_OPENED. Doing this to avoid
             # unnecessary processing on file open events, need this since watchdog
             # started sending EVENT_TYPE_OPENED events. Eventually refactor dispatch
-            # and event handlers later to do work only on specific events.
+            # and event handlers later to do work and logging only on specific events.
             return False
         ts = time.time()
         store = self.getStoreFromEvent(event)
@@ -291,6 +291,12 @@ class IncludingFilesHandler(watchdog.events.FileSystemEventHandler):
         self.incObserver = incObserver
 
     def dispatch(self, event):
+        if event.event_type == watchdog.events.EVENT_TYPE_OPENED:
+            # Do not update configuration for EVENT_TYPE_OPENED. Doing this to avoid
+            # unnecessary processing on file open events, need this since watchdog
+            # started sending EVENT_TYPE_OPENED events. Eventually refactor dispatch
+            # and event handlers later to do work and logging only on specific events.
+            return
         print('-'*78)
         print(event)
         if event.is_directory:


### PR DESCRIPTION
Same as in https://github.com/Shoobx/z3c.insist/pull/6 but I missed fixing second place where we are logging in dispatch method.