### PR TITLE
Tests without tracebacks

### DIFF
--- a/src/z3c/insist/enforce.py
+++ b/src/z3c/insist/enforce.py
@@ -301,8 +301,7 @@ class IncludingFilesHandler(watchdog.events.FileSystemEventHandler):
             # started sending EVENT_TYPE_OPENED events. Eventually refactor dispatch
             # and event handlers later to do work and logging only on specific events.
             return
-        print('-'*78)
-        print(event)
+        logger.info("Handling %s", event)
         if event.is_directory:
             return
 

--- a/src/z3c/insist/enforce.py
+++ b/src/z3c/insist/enforce.py
@@ -229,7 +229,11 @@ class Enforcer(watchdog.observers.Observer):
         self.schedule(handler, path=self.watchedDir, recursive=True)
 
     def dispatch_events(self, event_queue):
-        event, watch = event_queue.get(block=True)
+        ev =  event_queue.get(block=True)
+        if not isinstance(ev, tuple):
+            return
+        event, watch = ev
+
 
         with self._lock:
             # Optimization: Ignore all directory modified events, since we


### PR DESCRIPTION
Tests used to pass, but output a traceback like this:

```
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 980, in _bootstrap_inner
    self.run()
  File "/home/andrey/projects/shoobx/z3c.insist/ve/lib/python3.9/site-packages/watchdog/observers/api.py", line 204, in run
    self.dispatch_events(self.event_queue)
  File "/home/andrey/projects/shoobx/z3c.insist/src/z3c/insist/enforce.py", line 232, in dispatch_events
    event, watch = event_queue.get(block=True)
TypeError: cannot unpack non-iterable object object
```

Fix this broken window.