### PR TITLE
Use same algorithm for includes in configurationStore as in IncludeObserver.update method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix inconsistencies in calculating includes paths. Please note that signature of
+  SeparateFileConfigurationStoreMixIn.getIncludes has changed.
 
 
 1.5.2 (2023-05-05)

--- a/src/z3c/insist/insist.py
+++ b/src/z3c/insist/insist.py
@@ -15,6 +15,7 @@ import iso8601
 import json
 import logging
 import os
+import pathlib
 import re
 import zope.component
 import zope.schema
@@ -358,10 +359,11 @@ class SeparateFileConfigurationStoreMixIn(FilesystemMixin):
     def getConfigFilename(self):
         return self.section + '.ini'
 
-    def getIncludes(self, cfgstr):
-        basePath = self.getConfigPath()
+    def getIncludes(self, cfgstr, configPath):
+        configPath = pathlib.Path(configPath)
+        # use string representation for backward compatibility
         return [
-            os.path.normpath(os.path.join(basePath, include))
+            str(pathlib.Path(configPath.parent, include).resolve())
             for include in re.findall(RE_INCLUDES, cfgstr, re.MULTILINE)
         ]
 
@@ -394,7 +396,7 @@ class SeparateFileConfigurationStoreMixIn(FilesystemMixin):
     def _readSubConfig(self, configPath):
         with self.openFile(configPath, 'r') as fle:
             cfgstr = fle.read()
-        includes = self.getIncludes(cfgstr)
+        includes = self.getIncludes(cfgstr, configPath)
         for include in includes:
             if not self.fileExists(include):
                 raise ValueError(

--- a/src/z3c/insist/insist.py
+++ b/src/z3c/insist/insist.py
@@ -361,7 +361,7 @@ class SeparateFileConfigurationStoreMixIn(FilesystemMixin):
 
     def getIncludes(self, cfgstr, configPath):
         configPath = pathlib.Path(configPath)
-        # use string representation for backward compatibility
+        # use string representation for compatibility with rest of the code
         return [
             str(pathlib.Path(configPath.parent, include).resolve())
             for include in re.findall(RE_INCLUDES, cfgstr, re.MULTILINE)


### PR DESCRIPTION
Turns out if config files are nested and the config paths in `#include` statements are relative our methods `IncludeObserver.update`, and `SeparateFileConfigurationStoreMixIn.getIncludes` may behave differently.

`IncludeObserver.update` takes config filename parent as base to resolve relative path and `SeparateFileConfigurationStoreMixIn.getIncludes` uses baseConfig, which is defined on the user level. After this change both should behave in the same way.